### PR TITLE
Substitute html Link for onClick handler on Logo

### DIFF
--- a/src/pages/layout.tsx
+++ b/src/pages/layout.tsx
@@ -145,11 +145,12 @@ export function LayoutPage() {
       </Helmet>
       <div className="flex justify-between mb-4">
         <div className="flex gap-6 items-center">
-          <div
-            className="bg-white text-black flex items-center cursor-pointer rounded-2xl aspect-square px-1"
-            onClick={() => navigate("/")}>
-            <Logo width={40} height={40} />
-          </div>
+          <Link to="/" href="/">
+            <div
+              className="bg-white text-black flex items-center cursor-pointer rounded-2xl aspect-square px-1">
+              <Logo width={40} height={40} />
+            </div>
+          </Link>
           <SearchBar />
           <Link to="/category" className="max-xl:hidden">
             <FormattedMessage defaultMessage="Categories" id="VKb1MS" />


### PR DESCRIPTION
Testing done:

Confirmed this builds and runs. It appears to behave correctly in firefox with 123.0 (64-bit). It didn't appear to break anything.

Why we should do this:

- This is more semantic.
- I think this is better for accessibility, because it will get picked up as a clickable item by screen readers, and it can be accessed by cycling through clickable elements with the Tab key.
- This is a more conventional user experience: some users expect a website to allow them to "middle click" clickable elements (the changes in this PR allows "middle click" functionality).
- I don't know if there's any reason why we should not do this.
