### PR TITLE
fix: call video.play() after short delay to ensure cached video is playing on load

### DIFF
--- a/src/element/live-video-player.tsx
+++ b/src/element/live-video-player.tsx
@@ -51,6 +51,7 @@ export default function LiveVideoPlayer({
             lowLatencyMode: true,
             backBufferLength: 90,
           });
+          let timeout: NodeJS.Timeout;
           hls.loadSource(streamCached);
           hls.attachMedia(video.current);
           hls.on(Hls.Events.ERROR, (event, data) => {
@@ -74,6 +75,11 @@ export default function LiveVideoPlayer({
                 height: a.height,
               })),
             ]);
+            timeout = setTimeout(() => {
+              video.current?.play()
+                .catch(e =>
+                  console.log(e));
+            }, 1000);
           });
           hls.on(Hls.Events.LEVEL_SWITCHING, (_, l) => {
             console.debug("HLS Level Switch", l);
@@ -85,6 +91,7 @@ export default function LiveVideoPlayer({
             // @ts-ignore Can write anyway
             hlsObj.current = null;
             hls.destroy();
+            clearTimeout(timeout);
           };
         } catch (e) {
           console.error(e);

--- a/src/element/live-video-player.tsx
+++ b/src/element/live-video-player.tsx
@@ -77,8 +77,10 @@ export default function LiveVideoPlayer({
             ]);
             timeout = setTimeout(() => {
               video.current?.play()
-                .catch(e =>
-                  console.log(e));
+                .catch(e => {
+                  console.log(e);
+                  setPlayState("paused");
+                });
             }, 1000);
           });
           hls.on(Hls.Events.LEVEL_SWITCHING, (_, l) => {


### PR DESCRIPTION
Certain cached videos such as RHR and Stacker News Live don't automatically play. Examples: 
- https://zap.stream/naddr1qqjrzvrzx93njep4943rsde3956r2e3494sn2e3k943x2dpjxc6nwcf4xcckvqg4waehxw309aex2mrp0yhxgctdw4eju6t09upzpn6956apxcad0mfp8grcuugdysg44eepex68h50t73zcathmfs49qvzqqqrkvuk7aqfg
- https://zap.stream/naddr1qqjrze3exqexgwtz95enzetz956rgd3h95unxdtr95enydp4xcuxzd3ex5exyqg4waehxw309aex2mrp0yhxgctdw4eju6t09upzpn6956apxcad0mfp8grcuugdysg44eepex68h50t73zcathmfs49qvzqqqrkvut8e98y

This PR just adds a small delay and then attempts to call play on the video element after the manifest is parsed.

It also catches the exception that usually results from having too low of a "Media Engagement Index" and set the play state to paused:
> DOMException: play() failed because the user didn't interact with the document first. https://goo.gl/xX8pDD

working demo of this branch: 
https://zap.nostril.cam/naddr1qqjrzvrzx93njep4943rsde3956r2e3494sn2e3k943x2dpjxc6nwcf4xcckvqg3waehxw309ahx7um5wgh8w6twv5hsygx0gknt5ymr44ldyyaq0rn3p5jpzkh8y8ymg773a06ytr4wldxz55psgqqqwens76sav9