### PR TITLE
Fix various date issues in Planned stream interface

### DIFF
--- a/src/element/stream-editor/index.tsx
+++ b/src/element/stream-editor/index.tsx
@@ -145,7 +145,8 @@ export function StreamEditor({ ev, onFinish, options }: StreamEditorProps) {
     }
   }
 
-  const startsDate = new Date(parseInt(start ?? "0") * 1000);
+  const startsTimestamp = parseInt(start ?? (new Date() / 1000));
+  const startsDate = new Date(startsTimestamp * 1000);
 
   return (
     <>

--- a/src/element/stream-editor/index.tsx
+++ b/src/element/stream-editor/index.tsx
@@ -206,7 +206,7 @@ export function StreamEditor({ ev, onFinish, options }: StreamEditorProps) {
                 type="datetime-local"
                 value={`${startsDate.getFullYear().toString().padStart(4, "0")}-${(startsDate.getMonth() + 1).toString().padStart(2, "0")}-${startsDate.getDate().toString().padStart(2, "0")}T${startsDate.getHours().toString().padStart(2, "0")}:${startsDate.getMinutes().toString().padStart(2, "0")}`}
                 onChange={e => {
-                  setStart((e.target.valueAsNumber / 1000).toString());
+                  setStart((new Date(e.target.value) / 1000).toString());
                 }}
               />
             </StreamInput>

--- a/src/element/stream-editor/index.tsx
+++ b/src/element/stream-editor/index.tsx
@@ -203,7 +203,7 @@ export function StreamEditor({ ev, onFinish, options }: StreamEditorProps) {
             <StreamInput label={<FormattedMessage defaultMessage="Start Time" />}>
               <input
                 type="datetime-local"
-                value={`${startsDate.getFullYear().toString().padStart(4, "0")}-${startsDate.getMonth().toString().padStart(2, "0")}-${startsDate.getDate().toString().padStart(2, "0")}T${startsDate.getHours().toString().padStart(2, "0")}:${startsDate.getMinutes().toString().padStart(2, "0")}`}
+                value={`${startsDate.getFullYear().toString().padStart(4, "0")}-${(startsDate.getMonth() + 1).toString().padStart(2, "0")}-${startsDate.getDate().toString().padStart(2, "0")}T${startsDate.getHours().toString().padStart(2, "0")}:${startsDate.getMinutes().toString().padStart(2, "0")}`}
                 onChange={e => {
                   setStart((e.target.valueAsNumber / 1000).toString());
                 }}


### PR DESCRIPTION
This PR fixes the following issues when attempting to create a Planned stream:

* Adds 1 to the getMonth() call since that function starts at zero rather than one:
![image](https://github.com/user-attachments/assets/0bd6a848-cab5-449c-8607-4b92a09752b6)

* Default to the current date rather than a zero date if no date is selected:
![image](https://github.com/user-attachments/assets/eba5a3b2-d5de-48f0-ac60-c45661c26b58)

* Fix issue with valueAsNumber calculating the date in UTC versus the date picker calculating it in local time:
![image](https://github.com/user-attachments/assets/8320477e-7bdf-4692-a7ef-f9a3c27989a2)
