### PR TITLE
fix: check if publisher starts with npub rather than using isHex

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -1,4 +1,3 @@
-import { isHex } from "@snort/shared";
 import { EventKind, parseNostrLink } from "@snort/system";
 
 export const LIVE_STREAM = 30_311 as EventKind;
@@ -43,10 +42,10 @@ function loadWhitelist() {
     const list = import.meta.env.VITE_SINGLE_PUBLISHER as string | undefined;
     if (list) {
       return list.split(",").map(a => {
-        if (isHex(a)) {
-          return a;
-        } else {
+        if (a.startsWith('npub')) {
           return parseNostrLink(a).id;
+        } else {
+          return a;
         }
       });
     }


### PR DESCRIPTION
loadWhitelist seems to use `isHex` from Snort to determine whether each publisher string is a hex string or an npub string. 

The `isHex` function seems to check if a string is alphanumeric rather than if it's hexadecimal: https://github.com/v0l/snort/blob/aaa4b0de975986f083a469514feb194635139da5/packages/shared/src/utils.ts#L241-L248

Since npubs are all alphanumeric strings, the code misinterprets them as hex strings rather than as npubs.

This PR replaces the check with a simple check for `npub` at the start of the publisher string.