### PR TITLE
Added FAQ menu item

### DIFF
--- a/src/pages/layout/header.tsx
+++ b/src/pages/layout/header.tsx
@@ -102,6 +102,10 @@ export function HeaderNav() {
             <Icon name="widget" size={24} />
             <FormattedMessage defaultMessage="Widgets" />
           </MenuItem>
+          <MenuItem onClick={() => navigate("/faq")}>
+            <Icon name="link" size={24} />
+            <FormattedMessage defaultMessage="FAQ" />
+          </MenuItem>
           <MenuItem onClick={() => window.open("https://discord.gg/Wtg6NVDdbT")}>
             <Icon name="link" size={24} />
             Discord


### PR DESCRIPTION
Added missing FAQ menu item

![imagen](https://github.com/user-attachments/assets/fa6ec7de-42bf-4f16-a9a0-3fc8ec545020)

I'm not a dev, so I didn't know how to put a dedicated icon