### PR TITLE
Add shosho streaming server to P_TAG_HOST_WHITELIST

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -65,4 +65,5 @@ export const P_TAG_HOST_WHITELIST = [
   ZAP_STREAM_PUBKEY,
   "81ee947168db2f909895dbd4f71534f4040035575f58156e9a3802d1dd467e1d", //primalstream
   "f6a25b87f7e7bec9a691e37851b1b57a7b49fa00bb431280303002a3ebca4891", //streamstr (Grinder server)
+  "85df822a86599ffbe8143db1e1e1bf2d162fa60fc685c65515963e67cfd7499f", //shosho streaming server
 ];


### PR DESCRIPTION
This PR adds the shosho streaming server pubkey to the `P_TAG_HOST_WHITELIST` in `src/const.ts`.

__Changes:__

- Added pubkey `85df822a86599ffbe8143db1e1e1bf2d162fa60fc685c65515963e67cfd7499f` to the whitelist with comment `//shosho streaming server`

__Rationale:__ Shosho server uses Zap Stream Core backend, and verifies identities in the same way. Ideally, users of Shosho server who are tagged as Hosts would be presented as Hosts on the Zap Stream website.

__Testing:__

- The change follows the existing pattern used by primalstream and streamstr
- Only adds a single pubkey to the array with appropriate documentation

Thank you for your consideration.

Rod