### PR TITLE
Fix: Prefix game IDs with igdb: for proper tag format recognition

### DIFF
--- a/src/element/stream-editor/category-input.tsx
+++ b/src/element/stream-editor/category-input.tsx
@@ -28,7 +28,9 @@ export default function CategoryInput({
           <SearchCategory
             onSelect={g => {
               setGame(g)
-              setGameId(g.id)
+              // Prefix the game ID with igdb: for proper tag format recognition
+              const formattedId = g.id.startsWith("igdb:") ? g.id : `igdb:${g.id}`
+              setGameId(formattedId)
             }}
           />
         )}


### PR DESCRIPTION
This fixes the issue where updating stream info with a specific game fails because the game ID wasn't being properly formatted.

## Changes made
- Prefix IGDB game IDs with 'igdb:' when selected in the category input
- This ensures the game ID matches the expected tag format (^[a-z-]+:[a-z0-9-]+$)
- Allows proper extraction and recognition of game tags when reading stream info

## Testing notes
The fix ensures that when a user selects a specific game from the category input, the game ID is properly formatted with the 'igdb:' prefix. This allows the  function to correctly recognize and extract the game tag from the stream data.

Closes #56